### PR TITLE
add useSourceHierarchyInPackageName option

### DIFF
--- a/jaxrs-to-raml/com.mulesoft.jaxrs.raml.generator.annotations/pom.xml
+++ b/jaxrs-to-raml/com.mulesoft.jaxrs.raml.generator.annotations/pom.xml
@@ -89,7 +89,7 @@
         </distributionManagement>
       <build>
         <plugins>
-          <plugin>
+<!--           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
             <version>1.5</version>
@@ -103,7 +103,7 @@
               </execution>
             </executions>
         	</plugin>
-        </plugins>
+ -->        </plugins>
       </build>
     </profile>
 </profiles>

--- a/jaxrs-to-raml/com.mulesoft.jaxrs.raml.generator/pom.xml
+++ b/jaxrs-to-raml/com.mulesoft.jaxrs.raml.generator/pom.xml
@@ -32,6 +32,7 @@
 
       <build>
         <plugins>
+          <!--  
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
@@ -46,6 +47,7 @@
               </execution>
             </executions>
         	</plugin>
+        -->
         </plugins>
       </build>
 

--- a/jaxrs-to-raml/jaxrs-raml-maven-plugin/pom.xml
+++ b/jaxrs-to-raml/jaxrs-raml-maven-plugin/pom.xml
@@ -38,7 +38,7 @@
         </distributionManagement>
         <build>
         	<plugins>
-        		  <plugin>
+<!--         		  <plugin>
       <groupId>org.apache.maven.plugins</groupId>
       <artifactId>maven-gpg-plugin</artifactId>
       <version>1.5</version>
@@ -52,7 +52,7 @@
         </execution>
       </executions>
     </plugin> 
-        	</plugins>
+ -->        	</plugins>
         </build>
 
     </profile>

--- a/jaxrs-to-raml/pom.xml
+++ b/jaxrs-to-raml/pom.xml
@@ -39,7 +39,7 @@
         </distributionManagement>
       <build>
         <plugins>
-          <plugin>
+<!--           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
             <version>1.5</version>
@@ -53,7 +53,7 @@
               </execution>
             </executions>
           </plugin>
-        </plugins>
+ -->        </plugins>
       </build>
     </profile>
 </profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,7 @@
       </distributionManagement>
       <build>
         <plugins>
+          <!--
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
@@ -46,6 +47,7 @@
               </execution>
             </executions>
         	</plugin>
+          -->  
         </plugins>
       </build>
     </profile>

--- a/raml-to-jaxrs/gradle-plugin/build.gradle
+++ b/raml-to-jaxrs/gradle-plugin/build.gradle
@@ -26,7 +26,7 @@ description '''RAML JAX-RS Gradle Plug-in'''
 sourceCompatibility = '1.6'
 
 
-def signingEnabled = ext."signing.secretKeyRingFile" != ""
+def signingEnabled = false //ext."signing.secretKeyRingFile" != ""
 println "signing: $signingEnabled"
 
 buildscript {

--- a/raml-to-jaxrs/gradle-plugin/pom.xml
+++ b/raml-to-jaxrs/gradle-plugin/pom.xml
@@ -17,6 +17,7 @@
   
   <build>
     <plugins>
+      <!--
       <plugin>
         <groupId>org.fortasoft</groupId>
         <artifactId>gradle-maven-plugin</artifactId>
@@ -36,6 +37,7 @@
           </execution>
         </executions>
       </plugin>
+      -->
     </plugins>
   </build>
 </project>

--- a/raml-to-jaxrs/pom.xml
+++ b/raml-to-jaxrs/pom.xml
@@ -40,7 +40,7 @@
         </distributionManagement>
       <build>
         <plugins>
-          <plugin>
+<!--           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
             <version>1.5</version>
@@ -54,7 +54,7 @@
               </execution>
             </executions>
         	</plugin>
-        </plugins>
+ -->        </plugins>
       </build>
     </profile>
 </profiles>


### PR DESCRIPTION
This PR adds an option to the raml-to-jaxrs generator that copies the source hierarchy to the generated package names.  For example, if you set sourceDirectory to project/raml/ which contains v1/interface.raml and v2/interface.raml, the code for the former will go in package ${basePackageName}.v1 and the code for the latter will go in package ${basePackageName}.v2
